### PR TITLE
 yatch_house: add admin

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -26,10 +26,10 @@ development:
   adapter: postgresql
   encoding: unicode
   database: yatch_house_development
-  host: localhost
-  pool: 5
-  username: postgres
-  password: MyPassword
+  # host: localhost
+  # pool: 5
+  # username: postgres
+  # password: MyPassword
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -66,10 +66,10 @@ test:
   adapter: postgresql
   encoding: unicode
   database: yatch_house_test
-  host: localhost
-  pool: 5
-  username: postgres
-  password: MyPassword
+  # host: localhost
+  # pool: 5
+  # username: postgres
+  # password: MyPassword
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -96,8 +96,8 @@ production:
   adapter: postgresql
   encoding: unicode
   database: yatch_house_production
-  host: localhost
-  pool: 5
-  username: postgres
-  password: <%= ENV["YATCH_HOUSE_DATABASE_PASSWORD"] %>
-  role: MyRole
+  # host: localhost
+  # pool: 5
+  # username: postgres
+  # password: <%= ENV["YATCH_HOUSE_DATABASE_PASSWORD"] %>
+  # role: MyRole

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,11 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+User.create(
+    name: "Gedeon",
+    email: "gedeonadriel@gmail.com", 
+    password: "12345678", 
+    telephone: 1234567890,
+    admin: true
+)


### PR DESCRIPTION
##  yatch_house: add admin

 In this pull request I added the default admin user in `seeds.rb`, as follow:
`
User.create(`
 `   name: "Gedeon",`
 `   email: "gedeonadriel@gmail.com", `
`    password: "12345678", `
`    telephone: 1234567890,`
  `  admin: true`
)
`