### PR TITLE
API documentation (swagger)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,12 @@
 AllCops:
   NewCops: enable
   Exclude:
-    - "db/**/*"
-    - "bin/*" 
-    - "config/**/*"
-    - "Guardfile"
-    - "Rakefile"
-    - "node_modules/**/*"
+    - 'db/**/*'
+    - 'bin/*'
+    - 'config/**/*'
+    - 'Guardfile'
+    - 'Rakefile'
+    - 'node_modules/**/*'
 
   DisplayCopNames: true
 
@@ -14,19 +14,19 @@ Layout/LineLength:
   Max: 120
 Metrics/MethodLength:
   Include:
-    - "app/controllers/*"
-    - "app/models/*"
+    - 'app/controllers/*'
+    - 'app/models/*'
   Max: 20
 Metrics/AbcSize:
   Include:
-    - "app/controllers/*"
-    - "app/models/*"
+    - 'app/controllers/*'
+    - 'app/models/*'
   Max: 50
 Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
   IgnoredMethods: ['describe']
-  Max: 30
+  Max: 60
 
 Style/Documentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -60,4 +60,7 @@ gem 'devise-jwt'
 gem 'dotenv-rails', groups: %i[development test]
 
 gem 'carrierwave'
+
 gem 'cloudinary'
+
+gem 'rswag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     irb (1.4.1)
       reline (>= 0.3.0)
     json (2.6.2)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
     jwt (2.5.0)
     loofah (2.19.0)
@@ -251,6 +253,19 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.1)
+    rswag (2.6.0)
+      rswag-api (= 2.6.0)
+      rswag-specs (= 2.6.0)
+      rswag-ui (= 2.6.0)
+    rswag-api (2.6.0)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.6.0)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.1)
+    rswag-ui (2.6.0)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.36.0)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -312,6 +327,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.0.4)
   rspec-rails
+  rswag
   rubocop (>= 1.0, < 2.0)
   tzinfo-data
 

--- a/MIT.md
+++ b/MIT.md
@@ -1,0 +1,5 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of this App and associated documentation files, to deal in the App without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the App, and to permit persons to whom the App is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the App.
+
+THE App IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE App OR THE USE OR OTHER DEALINGS IN THE App.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ An application to book houses for rent like airbnb. The particularity is that th
 - LinkedIn: [yasin-warsame](https://linkedin.com/in/yasin-warsame-a4176217a)
 
 
+👤 **Author : IROTORI BAROKA**
 
+- LinkedIn: [![LinkedIn Badge](https://img.shields.io/badge/-baroka-white?logo=LinkedIn&logoColor=0A66C2&style=plastic)](https://linkedin.com/in/baroka)
+
+- GitHub: [![GitHub Badge](https://img.shields.io/badge/-baroka--wp-white?logo=GitHub&logoColor=181717&style=plastic)](https://github.com/baroka-wp)
+
+- Twitter: [![Twitter Badge](https://img.shields.io/badge/-birotori-white?logo=Twitter&logoColor=1DA1F2&style=plastic)](https://twitter.com/birotori)
+
+- Gmail: [![Gmail Badge](https://img.shields.io/badge/-baroka--Irotori-white?logo=Gmail&logoColor=EA4335&style=plastic)](mailto:birotori@gmail.com)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ An application to book houses for rent like airbnb. The particularity is that th
 - Twitter: [@Gedeon191](https://twitter.com/Gedeon191)
 - LinkedIn: [Ushindi Gedeon](https://linkedin.com/in/ushindi-gedeon)
 
+👤 **Author : YASIN WARSAME**
+
+- GitHub: [@Yazino12](https://github.com/Yazino12)
+- Twitter: [@yasino24](https://twitter.com/Gedeon191)
+- LinkedIn: [yasin-warsame](https://linkedin.com/in/yasin-warsame-a4176217a)
+
+
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,15 +1,97 @@
-# yatch_house
+# Yatch House API
 An application to book houses for rent like airbnb. The particularity is that the guests will live with their host to discover the local culture and customs. The user will be able to choose a house according to his preferences and book a period during which he will live with his guest.
 
-## TECH STACK
+## Built With
+
 - Ruby 3.1.2
 - Ruby on rails 7.0.3
 - postgresql (last version)
 
-## Front end github repo link
-[link]() [to update]
+## Getting Started
 
-## LIST OF FUNCTION
+To get a local copy up and running follow these simple example steps.
+
+### Prerequisites
+
+- A text editor(preferably Visual Studio Code)
+
+### Install
+
+- Ruby
+- Ruby on Rails
+- PostgresSQL
+- Rspec
+
+### Using it Locally
+
+- Clone the repository using the below commands.
+
+- `https://github.com/Baroka-wp/yatch_house.git `
+- `cd yatch_house`
+- `rails s`
+
+### Setup
+
+Install gems with:
+
+```
+bundle install
+```
+
+Setup database with:
+
+```
+rails db:create
+rails db:migrate
+```
+
+### Usage
+
+Start server with:
+
+```
+rails server
+```
+
+Visit http://localhost:3001/ in your browser.
+
+### Run tests
+
+Install npm with:
+
+```
+npm i
+```
+
+Install rspec with:
+
+```
+bundle install
+```
+
+and
+
+```
+rails generate rspec:install
+```
+
+run the test with:
+
+```
+rspec spec
+```
+
+### Check API Endpoints
+
+- Run your rails server rails s and go to the URL and add `/api-docs` and behold the Swagger UI documentation of all endpoints for the controllers.
+
+
+## Front end github repo link
+
+[front-end repo](https://github.com/Baroka-wp/yatch-house-front-end)
+
+## List of functions
+
 - Login/ registration
 - Check if user is admin
 - Add and delete house
@@ -18,10 +100,45 @@ An application to book houses for rent like airbnb. The particularity is that th
 - List of all house 
 - Check house is availableor not
 
-## DIAGRAM UML
+## Diagram UML
 
 ![yatch_house](https://user-images.githubusercontent.com/67879818/190388452-17991efb-e10e-44db-8398-20765877aae1.png)
-<<<<<<< HEAD
 
-=======
->>>>>>> main
+## API endpoints
+
+![image](https://user-images.githubusercontent.com/43172164/191965611-ca7fa9d7-23ca-43bd-92d9-f06363b3f032.png)
+
+## Authors
+
+👤 **Yasin Warsame**
+
+- GitHub: [@Yazino12](https://github.com/Yazino12)
+- Twitter: [@yasino24](https://twitter.com/yasino24)
+- LinkedIn: [yasin-warsame](https://linkedin.com/in/yasin-warsame-a4176217a)
+
+👤 **Gedion**
+
+- GitHub: [@GedeonTS]()
+- Twitter: []()
+- LinkedIn: []()
+
+👤 **Baroka**
+
+- GitHub: [@Baroka-wp]()
+- Twitter: []()
+- LinkedIn: []()
+
+## 🤝 Contributing
+
+Contributions, issues, and feature requests are welcome!
+
+Feel free to check the [issues page](https://github.com/Baroka-wp/yatch_house/issues).
+
+## Show your support
+
+Give a ⭐️ if you like this project!
+
+## Acknowledgments
+
+- Inspiration: Microverse
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Yatch House API
+
 An application to book houses for rent like airbnb. The particularity is that the guests will live with their host to discover the local culture and customs. The user will be able to choose a house according to his preferences and book a period during which he will live with his guest.
 
 ## Built With
@@ -85,7 +86,6 @@ rspec spec
 
 - Run your rails server rails s and go to the URL and add `/api-docs` and behold the Swagger UI documentation of all endpoints for the controllers.
 
-
 ## Front end github repo link
 
 [front-end repo](https://github.com/Baroka-wp/yatch-house-front-end)
@@ -97,7 +97,7 @@ rspec spec
 - Add and delete house
 - Add reservation
 - List of user reservations
-- List of all house 
+- List of all house
 - Check house is availableor not
 
 ## Diagram UML
@@ -142,3 +142,6 @@ Give a ⭐️ if you like this project!
 
 - Inspiration: Microverse
 
+## 📝 License
+
+This project is [MIT](./MIT.md) licensed.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,16 @@ An application to book houses for rent like airbnb. The particularity is that th
 ## DIAGRAM UML
 
 ![yatch_house](https://user-images.githubusercontent.com/67879818/190388452-17991efb-e10e-44db-8398-20765877aae1.png)
-<<<<<<< HEAD
 
-=======
->>>>>>> main
+
+## Author
+
+👤 **Author : GEDEON USHINDI**
+
+- GitHub: [@GedeonTS](https://github.com/GedeonTS)
+- Twitter: [@Gedeon191](https://twitter.com/Gedeon191)
+- LinkedIn: [Ushindi Gedeon](https://linkedin.com/in/ushindi-gedeon)
+
+
+
+## Contributing

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,12 +1,11 @@
 class Api::V1::UsersController < ApplicationController
-    def index
-      @users = User.all
-      render json: { data: @users }, status: :ok
-    end
-  
-    def show
-      @user = User.find(params[:id])
-      render json: { data: @user }, status: :ok
-    end
-
+  def index
+    @users = User.all
+    render json: { data: @users }, status: :ok
   end
+
+  def show
+    @user = User.find(params[:id])
+    render json: { data: @user }, status: :ok
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,10 @@ class ApplicationController < ActionController::API
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
- 
+
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:name,:email, :telephone, :admin, :password, :password_confirmation) }
+    devise_parameter_sanitizer.permit(:sign_up) do |u|
+      u.permit(:name, :email, :telephone, :admin, :password, :password_confirmation)
+    end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,13 +1,9 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   respond_to :json
 
-  def create
-    super #Nothing special here.
-  end
-
   protected
 
-  def sign_up(resource_name, resource)
+  def sign_up(_resource_name, _resource)
     true
   end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -26,10 +26,10 @@ development:
   adapter: postgresql
   encoding: unicode
   database: yatch_house_development
-  host: localhost
-  pool: 5
-  username: postgres
-  password: MyPassword
+  # host: localhost
+  # pool: 5
+  # username: postgres
+  # password: MyPassword
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -66,10 +66,10 @@ test:
   adapter: postgresql
   encoding: unicode
   database: yatch_house_test
-  host: localhost
-  pool: 5
-  username: postgres
-  password: MyPassword
+  # host: localhost
+  # pool: 5
+  # username: postgres
+  # password: MyPassword
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -96,8 +96,8 @@ production:
   adapter: postgresql
   encoding: unicode
   database: yatch_house_production
-  host: localhost
-  pool: 5
-  username: postgres
-  password: <%= ENV["YATCH_HOUSE_DATABASE_PASSWORD"] %>
-  role: MyRole
+  # host: localhost
+  # pool: 5
+  # username: postgres
+  # password: <%= ENV["YATCH_HOUSE_DATABASE_PASSWORD"] %>
+  # role: MyRole

--- a/config/database.yml
+++ b/config/database.yml
@@ -26,10 +26,10 @@ development:
   adapter: postgresql
   encoding: unicode
   database: yatch_house_development
-  # host: localhost
-  # pool: 5
-  # username: postgres
-  # password: MyPassword
+  host: localhost
+  pool: 5
+  username: postgres
+  password: MyPassword
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -66,10 +66,10 @@ test:
   adapter: postgresql
   encoding: unicode
   database: yatch_house_test
-  # host: localhost
-  # pool: 5
-  # username: postgres
-  # password: MyPassword
+  host: localhost
+  pool: 5
+  username: postgres
+  password: MyPassword
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -96,8 +96,8 @@ production:
   adapter: postgresql
   encoding: unicode
   database: yatch_house_production
-  # host: localhost
-  # pool: 5
-  # username: postgres
-  # password: <%= ENV["YATCH_HOUSE_DATABASE_PASSWORD"] %>
-  # role: MyRole
+  host: localhost
+  pool: 5
+  username: postgres
+  password: <%= ENV["YATCH_HOUSE_DATABASE_PASSWORD"] %>
+  role: MyRole

--- a/config/database.yml
+++ b/config/database.yml
@@ -31,36 +31,7 @@ development:
   # username: postgres
   # password: MyPassword
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: yatch_house
 
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   adapter: postgresql
@@ -71,26 +42,6 @@ test:
   # username: postgres
   # password: MyPassword
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
 production:
   <<: *default
   adapter: postgresql

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,10 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-# Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
-
-# Read more: https://github.com/cyu/rack-cors
-
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins "*"

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users,
   controllers: {
       sessions: 'users/sessions',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,6 @@ Rails.application.routes.draw do
       sessions: 'users/sessions',
       registrations: 'users/registrations'
   }
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
   namespace :api do
     namespace :v1 do
       resources :users, only: [:index, :show]

--- a/spec/requests/api/v1/houses_spec.rb
+++ b/spec/requests/api/v1/houses_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe 'api/v1/houses', type: :request do
 
     post('create house') do
       response(200, 'successful') do
+        consumes 'application/json'
+        parameter name: :house, in: :body, schema: {
+          type: :object,
+          properties: {
+            name: { type: :string },
+            location: { type: :string },
+            price: { type: :integer },
+            description: { type: :string },
+            image: { type: :string }
+          },
+          required: %w[name location price description image]
+        }
 
         after do |example|
           example.metadata[:response][:content] = {

--- a/spec/requests/api/v1/houses_spec.rb
+++ b/spec/requests/api/v1/houses_spec.rb
@@ -1,7 +1,117 @@
-require 'rails_helper'
+require 'swagger_helper'
 
-RSpec.describe 'Api::V1::Houses', type: :request do
-  describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe 'api/v1/houses', type: :request do
+
+  path '/api/v1/houses' do
+
+    get('list houses') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create house') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/houses/new' do
+
+    get('new house') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/houses/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show house') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    patch('update house') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    put('update house') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    delete('delete house') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/houses_spec.rb
+++ b/spec/requests/api/v1/houses_spec.rb
@@ -1,12 +1,9 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/houses', type: :request do
-
   path '/api/v1/houses' do
-
     get('list houses') do
       response(200, 'successful') do
-
         after do |example|
           example.metadata[:response][:content] = {
             'application/json' => {
@@ -46,10 +43,8 @@ RSpec.describe 'api/v1/houses', type: :request do
   end
 
   path '/api/v1/houses/new' do
-
     get('new house') do
       response(200, 'successful') do
-
         after do |example|
           example.metadata[:response][:content] = {
             'application/json' => {

--- a/spec/requests/api/v1/reservations_spec.rb
+++ b/spec/requests/api/v1/reservations_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe 'api/v1/reservations', type: :request do
 
     post('create reservation') do
       response(200, 'successful') do
+        consumes 'application/json'
+        parameter name: :reservation, in: :body, schema: {
+          type: :object,
+          properties: {
+            start_date: { type: :string },
+            end_date: { type: :string },
+            status: { type: :string },
+            house_id: { type: :integer },
+            user_id: { type: :integer }
+          },
+          required: %w[start_date end_date status house_id user_id]
+        }
 
         after do |example|
           example.metadata[:response][:content] = {

--- a/spec/requests/api/v1/reservations_spec.rb
+++ b/spec/requests/api/v1/reservations_spec.rb
@@ -1,7 +1,117 @@
-require 'rails_helper'
+require 'swagger_helper'
 
-RSpec.describe 'Api::V1::Reservations', type: :request do
-  describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe 'api/v1/reservations', type: :request do
+
+  path '/api/v1/reservations' do
+
+    get('list reservations') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create reservation') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/reservations/new' do
+
+    get('new reservation') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/reservations/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show reservation') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    patch('update reservation') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    put('update reservation') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    delete('delete reservation') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/reservations_spec.rb
+++ b/spec/requests/api/v1/reservations_spec.rb
@@ -1,12 +1,9 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/reservations', type: :request do
-
   path '/api/v1/reservations' do
-
     get('list reservations') do
       response(200, 'successful') do
-
         after do |example|
           example.metadata[:response][:content] = {
             'application/json' => {
@@ -46,10 +43,8 @@ RSpec.describe 'api/v1/reservations', type: :request do
   end
 
   path '/api/v1/reservations/new' do
-
     get('new reservation') do
       response(200, 'successful') do
-
         after do |example|
           example.metadata[:response][:content] = {
             'application/json' => {

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,12 +1,9 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/users', type: :request do
-
   path '/api/v1/users' do
-
     get('list users') do
       response(200, 'successful') do
-
         after do |example|
           example.metadata[:response][:content] = {
             'application/json' => {

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,41 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/users', type: :request do
+
+  path '/api/v1/users' do
+
+    get('list users') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/users/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show user') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
 RSpec.configure do |config|

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -27,7 +27,7 @@ RSpec.configure do |config|
           url: 'https://{defaultHost}',
           variables: {
             defaultHost: {
-              default: 'www.example.com'
+              default: '127.0.0.1:3001/'
             }
           }
         }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,120 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/v1/houses":
+    get:
+      summary: list houses
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create house
+      responses:
+        '200':
+          description: successful
+  "/api/v1/houses/new":
+    get:
+      summary: new house
+      responses:
+        '200':
+          description: successful
+  "/api/v1/houses/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show house
+      responses:
+        '200':
+          description: successful
+    patch:
+      summary: update house
+      responses:
+        '200':
+          description: successful
+    put:
+      summary: update house
+      responses:
+        '200':
+          description: successful
+    delete:
+      summary: delete house
+      responses:
+        '200':
+          description: successful
+  "/api/v1/reservations":
+    get:
+      summary: list reservations
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create reservation
+      responses:
+        '200':
+          description: successful
+  "/api/v1/reservations/new":
+    get:
+      summary: new reservation
+      responses:
+        '200':
+          description: successful
+  "/api/v1/reservations/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show reservation
+      responses:
+        '200':
+          description: successful
+    patch:
+      summary: update reservation
+      responses:
+        '200':
+          description: successful
+    put:
+      summary: update reservation
+      responses:
+        '200':
+          description: successful
+    delete:
+      summary: delete reservation
+      responses:
+        '200':
+          description: successful
+  "/api/v1/users":
+    get:
+      summary: list users
+      responses:
+        '200':
+          description: successful
+  "/api/v1/users/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show user
+      responses:
+        '200':
+          description: successful
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -12,9 +12,32 @@ paths:
           description: successful
     post:
       summary: create house
+      parameters: []
       responses:
         '200':
           description: successful
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                location:
+                  type: string
+                price:
+                  type: integer
+                description:
+                  type: string
+                image:
+                  type: string
+              required:
+              - name
+              - location
+              - price
+              - description
+              - image
   "/api/v1/houses/new":
     get:
       summary: new house
@@ -57,9 +80,32 @@ paths:
           description: successful
     post:
       summary: create reservation
+      parameters: []
       responses:
         '200':
           description: successful
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                start_date:
+                  type: string
+                end_date:
+                  type: string
+                status:
+                  type: string
+                house_id:
+                  type: integer
+                user_id:
+                  type: integer
+              required:
+              - start_date
+              - end_date
+              - status
+              - house_id
+              - user_id
   "/api/v1/reservations/new":
     get:
       summary: new reservation

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -117,4 +117,4 @@ servers:
 - url: https://{defaultHost}
   variables:
     defaultHost:
-      default: www.example.com
+      default: 127.0.0.1:3001/


### PR DESCRIPTION
### In this pull:

**Add API documentation:**

- Add rswag
- Run rswag:install and generate rswag files
- Generate houses_controller based spec for Swagger
- Generate reservations_controller based spec for Swagger
- Generate users_controller based spec for Swagger
- Update default host to localhost URL
- Add body params to houses request action
- Add body params to reservations request action

This closes #16 

_**Run your rails server rails s and go to the URL and add `/api-docs` and behold the Swagger UI documentation of all endpoints for the controllers.**_

[Swagger UI.pdf](https://github.com/Baroka-wp/yatch_house/files/9633551/Swagger.UI.pdf)


![image](https://user-images.githubusercontent.com/43172164/191958883-de6c5173-0ff7-44d6-a474-9bbb8267a1f0.png)
